### PR TITLE
Update `Absinthe.Relay.Connection.from_query` spec

### DIFF
--- a/lib/absinthe/relay/connection.ex
+++ b/lib/absinthe/relay/connection.ex
@@ -434,7 +434,8 @@ defmodule Absinthe.Relay.Connection do
 
   @type from_query_opts ::
           [
-            count: non_neg_integer
+            count: non_neg_integer,
+            max: pos_integer
           ]
           | from_slice_opts
 


### PR DESCRIPTION
The `max` keyword was missing.
It will fix dialer errors as described in absinthe-graphql/absinthe_relay#133.